### PR TITLE
tree: Add from_raw_pointer method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,7 +20,7 @@ checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
 name = "fdt-rs"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "endian-type-rs",
  "fallible-iterator",

--- a/src/base/tree.rs
+++ b/src/base/tree.rs
@@ -145,8 +145,7 @@ impl<'dt> DevTree<'dt> {
     ///
     /// Callers of this method the must guarantee the following:
     ///
-    /// - The passed buffer is 32-bit aligned.
-    /// - The passed buffer is exactly the length returned by [`Self::read_totalsize()`]
+    /// - The passed address is 32-bit aligned.
     #[inline]
     pub unsafe fn from_raw_pointer(addr: *const u8) -> Result<Self> {
         let buf: &[u8] = slice::from_raw_parts(addr, Self::MIN_HEADER_SIZE);

--- a/src/base/tree.rs
+++ b/src/base/tree.rs
@@ -114,7 +114,7 @@ impl<'dt> DevTree<'dt> {
     /// - The passed buffer is 32-bit aligned.
     /// - The passed buffer is exactly the length returned by [`Self::read_totalsize()`]
     #[inline]
-    fn from_safe_slice(buf: &'dt [u8]) -> Result<Self> {
+    unsafe fn from_safe_slice(buf: &'dt [u8]) -> Result<Self> {
         let ret = Self { buf };
         // Verify required alignment before returning.
         verify_offset_aligned::<u32>(ret.off_mem_rsvmap())?;

--- a/tests/parsing_test.rs
+++ b/tests/parsing_test.rs
@@ -102,6 +102,19 @@ fn nodes_iter() {
     }
 }
 
+#[test]
+fn nodes_iter_from_raw_pointer() {
+    unsafe {
+        let blob = DevTree::from_raw_pointer(&FDT[0] as *const u8).unwrap();
+        let iter = blob.nodes();
+        let mut pair_iter = iter.clone().zip(FBI(DFS_NODES.iter()));
+        while let Some((node, expected)) = pair_iter.next().unwrap() {
+            assert_eq!(node.name().unwrap(), *expected);
+        }
+        assert!(iter.count().unwrap() == DFS_NODES.len());
+    }
+}
+
 // Test that comparision of props works as expected.
 #[test]
 fn verify_prop_comparisions() {


### PR DESCRIPTION
Add a ``from_raw_pointer`` method that will create a slice with the correct size