### PR TITLE
Fix doc build of downstream no_std projects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,7 +20,7 @@ checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
 name = "fdt-rs"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "endian-type-rs",
  "fallible-iterator",

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -55,7 +55,7 @@
 //!
 //! ```
 //!
-#[cfg(doc)]
+#[cfg(all(doc, feature = "std"))]
 use crate::doctest::*;
 
 #[doc(hidden)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,7 @@ pub mod common;
 pub(crate) mod priv_util;
 
 // When the doctest feature is enabled, add these utility functions.
-#[cfg(any(feature = "doctest", doc))]
+#[cfg(all(any(feature = "doctest", doc), feature = "std"))]
 #[doc(hidden)]
 pub mod doctest {
     pub use crate::base::*;


### PR DESCRIPTION
Some of the doctests of this project require `std` and thereby break the docs build of any downstream `no_std` crates. I have disabled the offending ones when `feature = "std"` is missing.