### PR TITLE
Relative parsing navigation in fdt_rs::base

### DIFF
--- a/src/base/iters.rs
+++ b/src/base/iters.rs
@@ -94,6 +94,25 @@ impl<'a, 'dt: 'a> FallibleIterator for DevTreeNodeIter<'a, 'dt> {
     }
 }
 
+pub struct DevTreeNodeFilter<I>(pub I);
+impl<'a, 'dt: 'a, I> FallibleIterator for DevTreeNodeFilter<I>
+where
+    I: FallibleIterator<Item = DevTreeItem<'a, 'dt>>,
+{
+    type Error = I::Error;
+    type Item = DevTreeNode<'a, 'dt>;
+    fn next(&mut self) -> core::result::Result<Option<Self::Item>, Self::Error> {
+        loop {
+            match self.0.next() {
+                Ok(Some(DevTreeItem::Node(item))) => break Ok(Some(item)),
+                Ok(Some(_)) => {}
+                Ok(None) => break Ok(None),
+                Err(e) => break Err(e),
+            }
+        }
+    }
+}
+
 #[derive(Clone, PartialEq)]
 pub struct DevTreePropIter<'a, 'dt: 'a>(pub DevTreeIter<'a, 'dt>);
 impl<'a, 'dt: 'a> FallibleIterator for DevTreePropIter<'a, 'dt> {
@@ -104,6 +123,25 @@ impl<'a, 'dt: 'a> FallibleIterator for DevTreePropIter<'a, 'dt> {
     }
 }
 
+pub struct DevTreePropFilter<I>(pub I);
+impl<'a, 'dt: 'a, I> FallibleIterator for DevTreePropFilter<I>
+where
+    I: FallibleIterator<Item = DevTreeItem<'a, 'dt>>,
+{
+    type Error = I::Error;
+    type Item = DevTreeProp<'a, 'dt>;
+    fn next(&mut self) -> core::result::Result<Option<Self::Item>, Self::Error> {
+        loop {
+            match self.0.next() {
+                Ok(Some(DevTreeItem::Prop(p))) => break Ok(Some(p)),
+                Ok(Some(_)) => {}
+                Ok(None) => break Ok(None),
+                Err(e) => break Err(e),
+            }
+        }
+    }
+}
+
 #[derive(Clone, PartialEq)]
 pub struct DevTreeNodePropIter<'a, 'dt: 'a>(pub DevTreeIter<'a, 'dt>);
 impl<'a, 'dt: 'a> FallibleIterator for DevTreeNodePropIter<'a, 'dt> {
@@ -111,6 +149,22 @@ impl<'a, 'dt: 'a> FallibleIterator for DevTreeNodePropIter<'a, 'dt> {
     type Item = DevTreeProp<'a, 'dt>;
     fn next(&mut self) -> Result<Option<Self::Item>> {
         self.0.next_node_prop()
+    }
+}
+
+pub struct DevTreeNodePropFilter<I>(pub I);
+impl<'a, 'dt: 'a, I> FallibleIterator for DevTreeNodePropFilter<I>
+where
+    I: FallibleIterator<Item = DevTreeItem<'a, 'dt>>,
+{
+    type Error = I::Error;
+    type Item = DevTreeProp<'a, 'dt>;
+    fn next(&mut self) -> core::result::Result<Option<Self::Item>, Self::Error> {
+        match self.0.next() {
+            Ok(Some(item)) => Ok(item.prop()),
+            Ok(None) => Ok(None),
+            Err(e) => Err(e),
+        }
     }
 }
 

--- a/src/base/node.rs
+++ b/src/base/node.rs
@@ -102,4 +102,23 @@ impl<'a, 'dt: 'a> DevTreeNode<'a, 'dt> {
     pub fn next_sibling(&self) -> Result<Option<DevTreeNode<'a, 'dt>>> {
         self.sibling_nodes().next()
     }
+
+    /// Returns the [`DevTreeNode`] at the given path below this node.
+    pub fn node_at_path<'s, I>(&self, path: I) -> Result<Option<DevTreeNode<'a, 'dt>>>
+    where
+        I: Iterator<Item = &'s str>,
+    {
+        let mut current = self.clone();
+        for component in path {
+            if let Some(found) = current
+                .child_nodes()
+                .find(|node| Ok(node.name()? == component))?
+            {
+                current = found;
+            } else {
+                return Ok(None);
+            }
+        }
+        Ok(Some(current))
+    }
 }

--- a/src/base/node.rs
+++ b/src/base/node.rs
@@ -1,8 +1,13 @@
 #[cfg(doc)]
 use super::*;
 
-use crate::base::iters::{DevTreeIter, DevTreeNodePropIter};
+use crate::base::iters::{
+    DevTreeChildrenIter, DevTreeDescendantsIter, DevTreeIter, DevTreeNodeFilter,
+    DevTreeNodePropIter, DevTreeSiblingsAndDescendantsIter, DevTreeSiblingsIter,
+};
 use crate::error::Result;
+
+use fallible_iterator::FallibleIterator;
 
 /// A handle to a Device Tree Node within the device tree.
 #[derive(Clone)]
@@ -41,5 +46,60 @@ impl<'a, 'dt: 'a> DevTreeNode<'a, 'dt> {
     /// TODO
     pub fn find_next_compatible_node(&self, string: &str) -> Result<Option<DevTreeNode<'a, 'dt>>> {
         self.parse_iter.clone().next_compatible_node(string)
+    }
+
+    /// Return an iterator over all descendants of this node.
+    pub fn descendants(&self) -> DevTreeDescendantsIter<'a, 'dt> {
+        DevTreeDescendantsIter::new(self.parse_iter.clone())
+    }
+
+    /// Return an iterator over all descendant nodes of this node.
+    pub fn descendant_nodes(&self) -> DevTreeNodeFilter<DevTreeDescendantsIter<'a, 'dt>> {
+        DevTreeNodeFilter(self.descendants())
+    }
+
+    /// Return and iterator over all direct children of this node.
+    pub fn children(&self) -> DevTreeChildrenIter<'a, 'dt> {
+        DevTreeChildrenIter::new(self.parse_iter.clone())
+    }
+
+    /// Return an interator over all direct children nodes of this node.
+    pub fn child_nodes(&self) -> DevTreeNodeFilter<DevTreeChildrenIter<'a, 'dt>> {
+        DevTreeNodeFilter(self.children())
+    }
+
+    /// Return an iterator over all descendants of this node, all
+    /// siblings after the node and their descendants. If you only
+    /// want siblings and their descendants, but not this node's
+    /// descendants, first use [`next_sibling`](Self::next_sibling) and then
+    /// [`siblings_and_descendants`](Self::siblings_and_descendants) on that.
+    pub fn siblings_and_descendants(&self) -> DevTreeSiblingsAndDescendantsIter<'a, 'dt> {
+        DevTreeSiblingsAndDescendantsIter::new(self.parse_iter.clone())
+    }
+
+    /// Return and iterator over all descendant nodes and following
+    /// siblings nodes and their descendant nodes.
+    pub fn sibling_and_descendant_nodes(
+        &self,
+    ) -> DevTreeNodeFilter<DevTreeSiblingsAndDescendantsIter<'a, 'dt>> {
+        DevTreeNodeFilter(self.siblings_and_descendants())
+    }
+
+    /// Return an iterator over all later siblings of this node. Note
+    /// that this is dependant on the order of the siblings in the
+    /// DevTree as this can only return siblings that come after this
+    /// node, not previous siblings.
+    pub fn siblings(&self) -> DevTreeSiblingsIter<'a, 'dt> {
+        DevTreeSiblingsIter::new(self.parse_iter.clone())
+    }
+
+    /// Return and iterator over all later sibling nodes of this node.
+    pub fn sibling_nodes(&self) -> DevTreeNodeFilter<DevTreeSiblingsIter<'a, 'dt>> {
+        DevTreeNodeFilter(self.siblings())
+    }
+
+    /// Return the next sibling of this node.
+    pub fn next_sibling(&self) -> Result<Option<DevTreeNode<'a, 'dt>>> {
+        self.sibling_nodes().next()
     }
 }

--- a/src/base/tree.rs
+++ b/src/base/tree.rs
@@ -290,4 +290,16 @@ impl<'dt> DevTree<'dt> {
     pub fn root(&self) -> Result<Option<DevTreeNode<'_, 'dt>>> {
         self.nodes().next()
     }
+
+    /// Returns the [`DevTreeNode`] at the given path
+    pub fn node_at_path<'s, I>(&self, path: I) -> Result<Option<DevTreeNode<'_, 'dt>>>
+    where
+        I: Iterator<Item = &'s str>,
+    {
+        if let Some(root) = self.root()? {
+            root.node_at_path(path)
+        } else {
+            Ok(None)
+        }
+    }
 }


### PR DESCRIPTION
Currently `fdt_rs::base` only allows you to extract nodes themselves and their properties, but not to interrogate the tree structure between those node.

This creates a slightly awkward situation when searching for memory nodes to set up dynamic allocations. I would like to use structural information for this, because at this stage I'm only interested in memory nodes directly below the root. Not any that might be lingering around deeper into the structure. I wouldn't want to use `fdt_rs::index`, because I can't make dynamic allocations yet and creating some kind of static allocation would require me to make more assumptions about the memory layout before I can actually parse it. This can all be worked around, but I think we can do better.

This branch beefs up `DevTreeIter` a little, so we can instruct it to only return nodes and props in certain scopes relative to the current position. This is used by `DevTreeNode` to implement functions that can return iterators over

* a node's recursive descendants,
* a node's direct children,
* a node's recursive descendants, it's later siblings and all their recursive descendants and
* a node's later siblings.

It's slightly awkward that we can only return siblings from the current node onward and not previous siblings. But I don't see a way to do this efficiently without allocations, as we'd have to be able to remember and jump back to an arbitrary number of points along the parsed stream.

There's another slightly awkward limitation, that we have `siblings_and_descendants` which includes the current node's descendants, but no variant of that that excludes the current nodes descendants and only returns those of the siblings. This doesn't seem straightforward to implement without introducing another state parsing flag for just this use case. Since I don't have a practical use case for this at the moment, I didn't bother too much to implement it. If desired, the missing behavior can be emulated by calling `next_sibling` on a node and then calling `siblings_and_descendants` on that.