### PR TITLE
Loosen the lifetime constraints on DevTreeNode::props

### DIFF
--- a/src/base/node.rs
+++ b/src/base/node.rs
@@ -26,7 +26,7 @@ impl<'a, 'dt: 'a> DevTreeNode<'a, 'dt> {
 
     /// Returns an iterator over this node's children [`DevTreeProp`]
     #[must_use]
-    pub fn props(&'a self) -> DevTreeNodePropIter<'a, 'dt> {
+    pub fn props(&self) -> DevTreeNodePropIter<'a, 'dt> {
         DevTreeNodePropIter(self.parse_iter.clone())
     }
 


### PR DESCRIPTION
The returned DevTreeNodePropIter can outlive &self just fine, as long as it doesn't outlive the entire DevTree.