### PR TITLE
FIX: check compatible against the list of strings, not just one.

### DIFF
--- a/src/base/iters.rs
+++ b/src/base/iters.rs
@@ -224,8 +224,13 @@ impl<'a, 'dt: 'a> DevTreeIter<'a, 'dt> {
             loop {
                 match self.next_prop() {
                     Ok(Some(prop)) => {
-                        if prop.name()? == "compatible" && prop.str()? == string {
-                            return Ok(Some(prop.node()));
+                        if prop.name()? == "compatible" {
+                            let mut candidates = prop.iter_str();
+                            while let Some(s) = candidates.next()? {
+                                if s.eq(string) {
+                                    return Ok(Some(prop.node()));
+                                }
+                            }
                         }
                         continue;
                     }


### PR DESCRIPTION
In FDT, compatible property contains a list of compatible names. For instance on RPI4, UART have :
 compatible = "brcm,bcm2835-pl011", "arm,pl011", "arm,primecell";

before the patch, no devices where listed with
let mut node_iter = devtree.compatible_nodes("arm,pl011");

The patch corrects that