### PR TITLE
RFC: initial check for fdt and its containing buffer

### DIFF
--- a/src/base/tree.rs
+++ b/src/base/tree.rs
@@ -133,7 +133,7 @@ impl<'dt> DevTree<'dt> {
     /// - The passed buffer is exactly the length returned by [`Self::read_totalsize()`]
     #[inline]
     pub unsafe fn new(buf: &'dt [u8]) -> Result<Self> {
-        if Self::read_totalsize(buf)? < buf.len() {
+        if Self::read_totalsize(buf)? > buf.len() {
             Err(DevTreeError::ParseError)
         } else {
             Self::from_safe_slice(buf)


### PR DESCRIPTION
It is not inherently an error to have a containing buffer larger than the actual FDT. FDTs can be grown and hence a larger buffer may just accomodate expected growths.

However, a buffer that is actually smaller than the value in the FDT header does not represent a valid situation and it is better to bail off early.