### PR TITLE
Pass through std and alloc features to fallible-iterator dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,6 @@ rustc_version = "0.2"
 
 [features]
 default = ["std"]
-std = []
-alloc = []
+std = ["fallible-iterator/std"]
+alloc = ["fallible-iterator/alloc"]
 doctest = []


### PR DESCRIPTION
This is important to be able to collect a `FallibleIterator` into a `Vec`, for example.