### PR TITLE
Fix: Increase MAX_NODE_NAME_LEN to align with device tree specification

### DIFF
--- a/src/spec.rs
+++ b/src/spec.rs
@@ -5,7 +5,10 @@ use num_derive::FromPrimitive;
 /// Magic number used to denote the beginning of a device tree (as a native machine number).
 pub const FDT_MAGIC: u32 = 0xd00d_feed;
 /// Maximum length of a device tree node name (including null byte)
-pub const MAX_NODE_NAME_LEN: usize = 31;
+/// Format of node name string is (node-name@unit-address)
+/// node-name limit is 31 characters, while "@unit-address" depends on address size
+/// For a 64-bit address, "@unit-address" would be up to another 17 characters
+pub const MAX_NODE_NAME_LEN: usize = 48;
 
 /// Definition of the parsed phandle as a native machine number
 pub type Phandle = u32;


### PR DESCRIPTION
The device tree specification at https://devicetree-specification.readthedocs.io/en/latest/chapter2-devicetree-basics.html#node-names says the following:

    Each node in the devicetree is named according to the following convention:

        node-name@unit-address

    The node-name component specifies the name of the node. It shall be 1 to 31 characters

    ...

    The unit-address must match the first address specified in the reg property of the node.

To support up to a 64-bit address as part of the node name, the MAX_NODE_NAME_LEN constant has been increased from 31 characters to 48 characters.