### PR TITLE
Simplify lifetimes

### DIFF
--- a/src/base/item.rs
+++ b/src/base/item.rs
@@ -4,14 +4,14 @@ use crate::base::{DevTreeNode, DevTreeProp};
 
 /// An enum which contains either a [`DevTreeNode`] or a [`DevTreeProp`]
 #[derive(Clone, PartialEq)]
-pub enum DevTreeItem<'a, 'dt: 'a> {
-    Node(DevTreeNode<'a, 'dt>),
-    Prop(DevTreeProp<'a, 'dt>),
+pub enum DevTreeItem<'dt> {
+    Node(DevTreeNode<'dt>),
+    Prop(DevTreeProp<'dt>),
 }
 
-impl<'a, 'dt: 'a> UnwrappableDevTreeItem<'dt> for DevTreeItem<'a, 'dt> {
-    type TreeNode = DevTreeNode<'a, 'dt>;
-    type TreeProp = DevTreeProp<'a, 'dt>;
+impl<'dt> UnwrappableDevTreeItem<'dt> for DevTreeItem<'dt> {
+    type TreeNode = DevTreeNode<'dt>;
+    type TreeProp = DevTreeProp<'dt>;
 
     #[inline]
     fn node(self) -> Option<Self::TreeNode> {

--- a/src/base/iters.rs
+++ b/src/base/iters.rs
@@ -19,9 +19,9 @@ use fallible_iterator::FallibleIterator;
 
 /// An iterator over [`fdt_reserve_entry`] objects within the FDT.
 #[derive(Clone)]
-pub struct DevTreeReserveEntryIter<'a, 'dt: 'a> {
+pub struct DevTreeReserveEntryIter<'dt> {
     offset: usize,
-    fdt: &'a DevTree<'dt>,
+    fdt: DevTree<'dt>,
 }
 
 #[repr(transparent)]
@@ -33,8 +33,8 @@ impl<'dt> DevTreeReserveEntryRef<'dt> {
     }
 }
 
-impl<'a, 'dt: 'a> DevTreeReserveEntryIter<'a, 'dt> {
-    pub(crate) fn new(fdt: &'a DevTree<'dt>) -> Self {
+impl<'dt> DevTreeReserveEntryIter<'dt> {
+    pub(crate) fn new(fdt: DevTree<'dt>) -> Self {
         Self {
             offset: fdt.off_mem_rsvmap(),
             fdt,
@@ -42,7 +42,7 @@ impl<'a, 'dt: 'a> DevTreeReserveEntryIter<'a, 'dt> {
     }
 
     /// Return the current offset as a fdt_reserve_entry pointer.
-    unsafe fn ptr(&'a self) -> Result<DevTreeReserveEntryRef<'dt>> {
+    unsafe fn ptr(&self) -> Result<DevTreeReserveEntryRef<'dt>> {
         Ok(DevTreeReserveEntryRef(
             self.fdt.ptr_at(self.offset)?,
             PhantomData,
@@ -50,7 +50,7 @@ impl<'a, 'dt: 'a> DevTreeReserveEntryIter<'a, 'dt> {
     }
 }
 
-impl<'a, 'dt: 'a> Iterator for DevTreeReserveEntryIter<'a, 'dt> {
+impl<'dt> Iterator for DevTreeReserveEntryIter<'dt> {
     type Item = DevTreeReserveEntryRef<'dt>;
     fn next(&mut self) -> Option<Self::Item> {
         let next_offset = size_of::<fdt_reserve_entry>() + self.offset;
@@ -77,7 +77,7 @@ impl<'a, 'dt: 'a> Iterator for DevTreeReserveEntryIter<'a, 'dt> {
 
 /// An iterator over all [`DevTreeItem`] objects.
 #[derive(Clone, PartialEq)]
-pub struct DevTreeIter<'a, 'dt: 'a> {
+pub struct DevTreeIter<'dt> {
     /// Offset of the last opened Device Tree Node.
     /// This is used to set properties' parent DevTreeNode.
     ///
@@ -88,13 +88,13 @@ pub struct DevTreeIter<'a, 'dt: 'a> {
 
     /// Current offset into the flattened dt_struct section of the device tree.
     offset: usize,
-    pub(crate) fdt: &'a DevTree<'dt>,
+    pub(crate) fdt: DevTree<'dt>,
 }
 
 #[derive(Clone, PartialEq)]
-pub struct DevTreeNodeIter<'a, 'dt: 'a>(pub DevTreeIter<'a, 'dt>);
-impl<'a, 'dt: 'a> FallibleIterator for DevTreeNodeIter<'a, 'dt> {
-    type Item = DevTreeNode<'a, 'dt>;
+pub struct DevTreeNodeIter<'dt>(pub DevTreeIter<'dt>);
+impl<'dt> FallibleIterator for DevTreeNodeIter<'dt> {
+    type Item = DevTreeNode<'dt>;
     type Error = DevTreeError;
     fn next(&mut self) -> Result<Option<Self::Item>> {
         self.0.next_node()
@@ -102,40 +102,40 @@ impl<'a, 'dt: 'a> FallibleIterator for DevTreeNodeIter<'a, 'dt> {
 }
 
 #[derive(Clone, PartialEq)]
-pub struct DevTreePropIter<'a, 'dt: 'a>(pub DevTreeIter<'a, 'dt>);
-impl<'a, 'dt: 'a> FallibleIterator for DevTreePropIter<'a, 'dt> {
+pub struct DevTreePropIter<'dt>(pub DevTreeIter<'dt>);
+impl<'dt> FallibleIterator for DevTreePropIter<'dt> {
     type Error = DevTreeError;
-    type Item = DevTreeProp<'a, 'dt>;
+    type Item = DevTreeProp<'dt>;
     fn next(&mut self) -> Result<Option<Self::Item>> {
         self.0.next_prop()
     }
 }
 
 #[derive(Clone, PartialEq)]
-pub struct DevTreeNodePropIter<'a, 'dt: 'a>(pub DevTreeIter<'a, 'dt>);
-impl<'a, 'dt: 'a> FallibleIterator for DevTreeNodePropIter<'a, 'dt> {
+pub struct DevTreeNodePropIter<'dt>(pub DevTreeIter<'dt>);
+impl<'dt> FallibleIterator for DevTreeNodePropIter<'dt> {
     type Error = DevTreeError;
-    type Item = DevTreeProp<'a, 'dt>;
+    type Item = DevTreeProp<'dt>;
     fn next(&mut self) -> Result<Option<Self::Item>> {
         self.0.next_node_prop()
     }
 }
 
 #[derive(Clone, PartialEq)]
-pub struct DevTreeCompatibleNodeIter<'s, 'a, 'dt: 'a> {
-    pub iter: DevTreeIter<'a, 'dt>,
+pub struct DevTreeCompatibleNodeIter<'s, 'dt> {
+    pub iter: DevTreeIter<'dt>,
     pub string: &'s str,
 }
-impl<'s, 'a, 'dt: 'a> FallibleIterator for DevTreeCompatibleNodeIter<'s, 'a, 'dt> {
+impl<'s, 'dt> FallibleIterator for DevTreeCompatibleNodeIter<'s, 'dt> {
     type Error = DevTreeError;
-    type Item = DevTreeNode<'a, 'dt>;
+    type Item = DevTreeNode<'dt>;
     fn next(&mut self) -> Result<Option<Self::Item>> {
         self.iter.next_compatible_node(self.string)
     }
 }
 
-impl<'a, 'dt: 'a> DevTreeIter<'a, 'dt> {
-    pub fn new(fdt: &'a DevTree<'dt>) -> Self {
+impl<'dt> DevTreeIter<'dt> {
+    pub fn new(fdt: DevTree<'dt>) -> Self {
         Self {
             offset: fdt.off_dt_struct(),
             current_prop_parent_off: None,
@@ -143,7 +143,7 @@ impl<'a, 'dt: 'a> DevTreeIter<'a, 'dt> {
         }
     }
 
-    fn current_node_itr(&self) -> Option<DevTreeIter<'a, 'dt>> {
+    fn current_node_itr(&self) -> Option<DevTreeIter<'dt>> {
         self.current_prop_parent_off.map(|offset| DevTreeIter {
             fdt: self.fdt,
             current_prop_parent_off: Some(offset),
@@ -151,7 +151,7 @@ impl<'a, 'dt: 'a> DevTreeIter<'a, 'dt> {
         })
     }
 
-    pub fn last_node(mut self) -> Option<DevTreeNode<'a, 'dt>> {
+    pub fn last_node(mut self) -> Option<DevTreeNode<'dt>> {
         if let Some(off) = self.current_prop_parent_off.take() {
             self.offset = off.get();
             return self.next_node().unwrap();
@@ -159,7 +159,7 @@ impl<'a, 'dt: 'a> DevTreeIter<'a, 'dt> {
         None
     }
 
-    pub fn next_item(&mut self) -> Result<Option<DevTreeItem<'a, 'dt>>> {
+    pub fn next_item(&mut self) -> Result<Option<DevTreeItem<'dt>>> {
         loop {
             let old_offset = self.offset;
             // Safe because we only pass offsets which are returned by next_devtree_token.
@@ -198,7 +198,7 @@ impl<'a, 'dt: 'a> DevTreeIter<'a, 'dt> {
         }
     }
 
-    pub fn next_prop(&mut self) -> Result<Option<DevTreeProp<'a, 'dt>>> {
+    pub fn next_prop(&mut self) -> Result<Option<DevTreeProp<'dt>>> {
         loop {
             match self.next() {
                 Ok(Some(DevTreeItem::Prop(p))) => return Ok(Some(p)),
@@ -209,7 +209,7 @@ impl<'a, 'dt: 'a> DevTreeIter<'a, 'dt> {
         }
     }
 
-    pub fn next_node(&mut self) -> Result<Option<DevTreeNode<'a, 'dt>>> {
+    pub fn next_node(&mut self) -> Result<Option<DevTreeNode<'dt>>> {
         loop {
             match self.next() {
                 Ok(Some(DevTreeItem::Node(n))) => return Ok(Some(n)),
@@ -220,7 +220,7 @@ impl<'a, 'dt: 'a> DevTreeIter<'a, 'dt> {
         }
     }
 
-    pub fn next_node_prop(&mut self) -> Result<Option<DevTreeProp<'a, 'dt>>> {
+    pub fn next_node_prop(&mut self) -> Result<Option<DevTreeProp<'dt>>> {
         match self.next() {
             // Return if a new node or an EOF.
             Ok(Some(item)) => Ok(item.prop()),
@@ -229,7 +229,7 @@ impl<'a, 'dt: 'a> DevTreeIter<'a, 'dt> {
         }
     }
 
-    pub fn next_compatible_node(&mut self, string: &str) -> Result<Option<DevTreeNode<'a, 'dt>>> {
+    pub fn next_compatible_node(&mut self, string: &str) -> Result<Option<DevTreeNode<'dt>>> {
         // If there is another node, advance our iterator to that node.
         self.next_node().and_then(|_| {
             // Iterate through all remaining properties in the tree looking for the compatible
@@ -255,9 +255,9 @@ impl<'a, 'dt: 'a> DevTreeIter<'a, 'dt> {
     }
 }
 
-impl<'a, 'dt: 'a> FallibleIterator for DevTreeIter<'a, 'dt> {
+impl<'dt> FallibleIterator for DevTreeIter<'dt> {
     type Error = DevTreeError;
-    type Item = DevTreeItem<'a, 'dt>;
+    type Item = DevTreeItem<'dt>;
 
     fn next(&mut self) -> Result<Option<Self::Item>> {
         self.next_item()

--- a/src/base/node.rs
+++ b/src/base/node.rs
@@ -6,27 +6,27 @@ use crate::error::Result;
 
 /// A handle to a Device Tree Node within the device tree.
 #[derive(Clone)]
-pub struct DevTreeNode<'a, 'dt: 'a> {
+pub struct DevTreeNode<'dt> {
     pub(super) name: Result<&'dt str>,
-    pub(super) parse_iter: DevTreeIter<'a, 'dt>,
+    pub(super) parse_iter: DevTreeIter<'dt>,
 }
 
-impl<'a, 'dt: 'a> PartialEq for DevTreeNode<'a, 'dt> {
+impl<'dt> PartialEq for DevTreeNode<'dt> {
     fn eq(&self, other: &Self) -> bool {
         self.parse_iter == other.parse_iter
     }
 }
 
-impl<'a, 'dt: 'a> DevTreeNode<'a, 'dt> {
+impl<'dt> DevTreeNode<'dt> {
     /// Returns the name of the `DevTreeNode` (including unit address tag)
     #[inline]
-    pub fn name(&'a self) -> Result<&'dt str> {
+    pub fn name(&self) -> Result<&'dt str> {
         self.name
     }
 
     /// Returns an iterator over this node's children [`DevTreeProp`]
     #[must_use]
-    pub fn props(&self) -> DevTreeNodePropIter<'a, 'dt> {
+    pub fn props(&self) -> DevTreeNodePropIter<'dt> {
         DevTreeNodePropIter(self.parse_iter.clone())
     }
 
@@ -39,7 +39,7 @@ impl<'a, 'dt: 'a> DevTreeNode<'a, 'dt> {
     /// and prints each node's name.
     ///
     /// TODO
-    pub fn find_next_compatible_node(&self, string: &str) -> Result<Option<DevTreeNode<'a, 'dt>>> {
+    pub fn find_next_compatible_node(&self, string: &str) -> Result<Option<DevTreeNode<'dt>>> {
         self.parse_iter.clone().next_compatible_node(string)
     }
 }

--- a/src/base/parse.rs
+++ b/src/base/parse.rs
@@ -132,13 +132,13 @@ pub enum ParsedTok<'a> {
 }
 
 #[derive(Debug, PartialEq)]
-pub struct DevTreeParseIter<'r, 'dt: 'r> {
+pub struct DevTreeParseIter<'dt> {
     pub offset: usize,
-    pub fdt: &'r DevTree<'dt>,
+    pub fdt: DevTree<'dt>,
 }
 
-impl<'r, 'dt: 'r> DevTreeParseIter<'r, 'dt> {
-    pub fn new(fdt: &'r DevTree<'dt>) -> Self {
+impl<'dt> DevTreeParseIter<'dt> {
+    pub fn new(fdt: DevTree<'dt>) -> Self {
         Self {
             offset: fdt.off_dt_struct(),
             fdt,
@@ -146,9 +146,9 @@ impl<'r, 'dt: 'r> DevTreeParseIter<'r, 'dt> {
     }
 }
 
-impl<'dt, 'a: 'dt> FallibleIterator for DevTreeParseIter<'dt, 'a> {
+impl<'dt> FallibleIterator for DevTreeParseIter<'dt> {
     type Error = DevTreeError;
-    type Item = ParsedTok<'a>;
+    type Item = ParsedTok<'dt>;
 
     fn next(&mut self) -> Result<Option<Self::Item>> {
         // Safe because we're passing an unmodified (by us) offset.

--- a/src/base/prop.rs
+++ b/src/base/prop.rs
@@ -8,13 +8,13 @@ use unsafe_unwrap::UnsafeUnwrap;
 
 /// A handle to a [`DevTreeNode`]'s Device Tree Property
 #[derive(Clone)]
-pub struct DevTreeProp<'a, 'dt: 'a> {
-    parent_iter: DevTreeIter<'a, 'dt>,
+pub struct DevTreeProp<'dt> {
+    parent_iter: DevTreeIter<'dt>,
     propbuf: &'dt [u8],
     nameoff: usize,
 }
 
-impl<'a, 'dt: 'a> PartialEq for DevTreeProp<'a, 'dt> {
+impl<'dt> PartialEq for DevTreeProp<'dt> {
     fn eq(&self, other: &Self) -> bool {
         ptr::eq(self.propbuf, other.propbuf)
             && self.parent_iter == other.parent_iter
@@ -22,8 +22,8 @@ impl<'a, 'dt: 'a> PartialEq for DevTreeProp<'a, 'dt> {
     }
 }
 
-impl<'r, 'dt: 'r> PropReader<'dt> for DevTreeProp<'r, 'dt> {
-    type NodeType = DevTreeNode<'r, 'dt>;
+impl<'dt> PropReader<'dt> for DevTreeProp<'dt> {
+    type NodeType = DevTreeNode<'dt>;
 
     #[inline]
     fn propbuf(&self) -> &'dt [u8] {
@@ -37,12 +37,12 @@ impl<'r, 'dt: 'r> PropReader<'dt> for DevTreeProp<'r, 'dt> {
 
     #[inline]
     fn fdt(&self) -> &DevTree<'dt> {
-        self.parent_iter.fdt
+        &self.parent_iter.fdt
     }
 
     /// Returns the node which this property is attached to
     #[must_use]
-    fn node(&self) -> DevTreeNode<'r, 'dt> {
+    fn node(&self) -> DevTreeNode<'dt> {
         unsafe {
             // Unsafe unwrap okay.
             // We're look back in the tree - our parent node is behind us.
@@ -51,9 +51,9 @@ impl<'r, 'dt: 'r> PropReader<'dt> for DevTreeProp<'r, 'dt> {
     }
 }
 
-impl<'a, 'dt: 'a> DevTreeProp<'a, 'dt> {
+impl<'dt> DevTreeProp<'dt> {
     pub(super) fn new(
-        parent_iter: DevTreeIter<'a, 'dt>,
+        parent_iter: DevTreeIter<'dt>,
         propbuf: &'dt [u8],
         nameoff: usize,
     ) -> Self {

--- a/src/base/tree.rs
+++ b/src/base/tree.rs
@@ -246,22 +246,22 @@ impl<'dt> DevTree<'dt> {
     /// Returns an iterator over the Dev Tree "5.3 Memory Reservation Blocks"
     #[must_use]
     pub fn reserved_entries(&self) -> DevTreeReserveEntryIter {
-        DevTreeReserveEntryIter::new(self)
+        DevTreeReserveEntryIter::new(self.clone())
     }
 
     /// Returns an iterator over [`DevTreeNode`] objects
-    pub fn nodes(&self) -> DevTreeNodeIter<'_, 'dt> {
-        DevTreeNodeIter(DevTreeIter::new(self))
+    pub fn nodes(&self) -> DevTreeNodeIter<'dt> {
+        DevTreeNodeIter(DevTreeIter::new(self.clone()))
     }
 
     #[must_use]
-    pub fn props(&self) -> DevTreePropIter<'_, 'dt> {
-        DevTreePropIter(DevTreeIter::new(self))
+    pub fn props(&self) -> DevTreePropIter<'dt> {
+        DevTreePropIter(DevTreeIter::new(self.clone()))
     }
 
     /// Returns an iterator over objects within the [`DevTreeItem`] enum
-    pub fn items(&self) -> DevTreeIter<'_, 'dt> {
-        DevTreeIter::new(self)
+    pub fn items(&self) -> DevTreeIter<'dt> {
+        DevTreeIter::new(self.clone())
     }
 
     /// Returns an iterator over low level parsing tokens, [`ParsedTok`].
@@ -275,7 +275,7 @@ impl<'dt> DevTree<'dt> {
     pub fn compatible_nodes<'s, 'a: 's>(
         &'a self,
         string: &'s str,
-    ) -> DevTreeCompatibleNodeIter<'s, 'a, 'dt> {
+    ) -> DevTreeCompatibleNodeIter<'s, 'dt> {
         DevTreeCompatibleNodeIter {
             iter: self.items(),
             string,
@@ -287,7 +287,7 @@ impl<'dt> DevTree<'dt> {
     }
 
     /// Returns the root [`DevTreeNode`] object of the device tree (if it exists).
-    pub fn root(&self) -> Result<Option<DevTreeNode<'_, 'dt>>> {
+    pub fn root(&self) -> Result<Option<DevTreeNode<'dt>>> {
         self.nodes().next()
     }
 }

--- a/src/base/tree.rs
+++ b/src/base/tree.rs
@@ -266,8 +266,8 @@ impl<'dt> DevTree<'dt> {
 
     /// Returns an iterator over low level parsing tokens, [`ParsedTok`].
     #[must_use]
-    pub fn parse_iter(&self) -> DevTreeParseIter<'_, 'dt> {
-        DevTreeParseIter::new(self)
+    pub fn parse_iter(&self) -> DevTreeParseIter<'dt> {
+        DevTreeParseIter::new(self.clone())
     }
 
     /// Returns the first [`DevTreeNode`] object with the provided compatible device tree property

--- a/src/index/tree.rs
+++ b/src/index/tree.rs
@@ -266,7 +266,7 @@ impl<'i, 'dt: 'i> DevTreeIndex<'i, 'dt> {
         // + size_of::<DTINode>
         const_assert_eq!(align_of::<DTINode>(), align_of::<DTIProp>());
 
-        let mut iter = DevTreeIter::new(fdt);
+        let mut iter = DevTreeIter::new(fdt.clone());
         while let Some(item) = iter.next()? {
             match item {
                 DevTreeItem::Node(_) => size += size_of::<DTINode>(),

--- a/src/index/tree.rs
+++ b/src/index/tree.rs
@@ -223,7 +223,7 @@ impl<'i, 'dt: 'i> DevTreeIndex<'i, 'dt> {
     // - It is very easy to test in isolation; parsing is entirely enclosed to this module.
     unsafe fn init_builder<'a>(
         buf: &'i mut [u8],
-        iter: &mut DevTreeParseIter<'a, 'dt>,
+        iter: &mut DevTreeParseIter<'dt>,
     ) -> Result<DTIBuilder<'i, 'dt>, DevTreeError> {
         let mut builder = DTIBuilder {
             front_off: 0,
@@ -286,7 +286,7 @@ impl<'i, 'dt: 'i> DevTreeIndex<'i, 'dt> {
     }
 
     pub fn new(fdt: DevTree<'dt>, buf: &'i mut [u8]) -> Result<Self, DevTreeError> {
-        let mut iter = DevTreeParseIter::new(&fdt);
+        let mut iter = DevTreeParseIter::new(fdt);
 
         let mut builder = unsafe { Self::init_builder(buf, &mut iter) }?;
 


### PR DESCRIPTION
Hi,

looking through this crate, I noticed that there were lots of lifetime parameters, some of which aren't useful IMO. In this MR, I'm proposing a refactoring to simplify the lifetimes while also making the crate more flexible:

There are several types in this crate that contain a `DevTree`, which is a wrapper around `&[u8]`. These types currently contain a reference to the devtree, for example `fdt: &'a DevTree<'dt>`. This makes it a double reference (`&'a &'dt [u8]` basically) and the outer reference doesn't provide significant value. I've therefore replaced occurrences of `&'a DevTree<'dt>` in several types with `DevTree<'dt>` (changing the attribute from being a reference to being a value). Here's a diff of one of the types I've changed:

```diff
-pub struct DevTreeParseIter<'r, 'dt: 'r> {
+pub struct DevTreeParseIter<'dt> {
     pub offset: usize,
-    pub fdt: &'r DevTree<'dt>,
+    pub fdt: DevTree<'dt>,
 }
```

`DevTree` has the memory layout of a slice, which is a fat pointer (pointer + length). Storing it by value instead of by reference makes the type containing it slightly larger, but also removes one level of indirection (which is good for cache locality).

The other (more important) effect of this change is that it removes a lifetime parameter from lots of definitions. It also makes the APIs more flexible:

Currently, one needs to create an instance of `DevTree` which must outlive all iterators created from it. Something like this currently doesn't compile:

```rust
#[test]
fn test() {
    let data = [1,2,3, /* ... */];
    let mut iter = {
        let blob = unsafe { DevTree::new(&data).unwrap() };
        DevTreeNodeIter(DevTreeIter::new(&blob))
        //                                ^^^^^ borrowed value does not live long enough
    };

    while let Some(x) = iter.next().unwrap() {
        dbg!(x.name().unwrap());
    }
}
```

With the proposed refactoring, this works fine:

```rust
#[test]
fn test() {
    let data = [1,2,3, /* ... */];
    let mut iter = {
        let blob = unsafe { DevTree::new(&data).unwrap() };
        DevTreeNodeIter(DevTreeIter::new(blob))
    };

    while let Some(x) = iter.next().unwrap() {
        dbg!(x.name().unwrap());
    }
}
```

`DevTree` isn't required to outlive `DevTreeIter` anymore, which is more flexible. The remaining `'dt` lifetime makes sure that the data outlives `DevTreeIter`. Putting the data into the inner scope in the exmple above like this won't compile:

```rust
#[test]
fn test() {
    let mut iter = {
        let data = [1,2,3, /* ... */];
        let blob = unsafe { DevTree::new(&data).unwrap() };
        //                               ^^^^^ borrowed value does not live long enough
        DevTreeNodeIter(DevTreeIter::new(blob))
    };

    while let Some(x) = iter.next().unwrap() {
        dbg!(x.name().unwrap());
    }
}
```

Storing `DevTree` by value meant that I had to clone it in a couple of places. That's not an issue though IMO as it simply copies the fat pointer (16 bytes on a 64 bit system).

Let me know if you have questions regarding this MR. 

Looking forward to hearing from you!
